### PR TITLE
Ltsmaint 746

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get -y install maven && \
     mkdir -p /home/librarycloud/ingest/cameldata && \
     cd  /home/librarycloud/ && git clone https://github.com/harvard-library/librarycloud_ingest.git && \
-    cd /home/librarycloud/librarycloud_ingest && git checkout LTSCLOUD-1125 && \
+    cd /home/librarycloud/librarycloud_ingest && git checkout LTSMAINT-746 && \
     useradd --uid 55003 -m lcadm
 WORKDIR /home/librarycloud/librarycloud_ingest
 COPY --chown=lcadm ./ .

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.version>5.2.22.RELEASE</spring.version>
+    <spring.version>5.2.24.RELEASE</spring.version>
     <!-- last release compatible with Camel 2.17.7 -->
     <openjpa.version>2.3.0</openjpa.version>
     <camel.version>2.24.3</camel.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.version>5.2.24.RELEASE</spring.version>
+    <spring.version>5.2.22.RELEASE</spring.version>
     <!-- last release compatible with Camel 2.17.7 -->
     <openjpa.version>2.3.0</openjpa.version>
     <camel.version>2.24.3</camel.version>

--- a/src/main/resources/eadcomponent2mods.xsl
+++ b/src/main/resources/eadcomponent2mods.xsl
@@ -10,7 +10,7 @@
     <xsl:strip-space elements="*"/>
     <xsl:param name="componentid"></xsl:param>
     <!-- comment above, uncomment below for testing (you can change the id -->
-    <!--<xsl:param name="componentid">gut5000c00014</xsl:param>-->
+    <!--<xsl:param name="componentid">GUT50000c01647</xsl:param>-->
     <xsl:key name="roletextlookup" match="roles:map" use="roles:code"/>
     <xsl:variable name="originationroles"
         select="document('src/main/resources/originationroles.xml')/roles:originationroles"/>
@@ -44,6 +44,7 @@
             <xsl:apply-templates select="$cmatch/c/controlaccess"/>
             <xsl:apply-templates select="$cmatch/c/odd"/>
             <xsl:apply-templates select="$cmatch/c/prefercite[head = 'Preferred Citation']"/>
+            <xsl:apply-templates select="$cmatch/c/originalsloc[head = 'Existence and Location of Originals']"/>
             <xsl:apply-templates select="$cmatch/c/userestrict"/>
             <xsl:apply-templates select="//c[@id = $cid_legacy_or_new]" mode="lang"/>
             <xsl:apply-templates
@@ -138,6 +139,7 @@
                 <xsl:apply-templates select="parent::c/controlaccess"/>
                 <xsl:apply-templates select="parent::c/odd"/>
                 <xsl:apply-templates select="parent::c/prefercite[head = 'Preferred Citation']"/>
+                <xsl:apply-templates select="parent::c/originalsloc[head = 'Existence and Location of Originals']"/>
                 <xsl:apply-templates select="parent::c/userestrict"/>
                 <xsl:apply-templates
                     select="parent::c/altformavail[head = 'Existence and Location of Copies']"/>
@@ -601,6 +603,12 @@
     <xsl:template match="prefercite[head = 'Preferred Citation']">
         <xsl:element name="note">
             <xsl:attribute name="type">preferred citation</xsl:attribute>
+            <xsl:value-of select="normalize-space(p)"/>
+        </xsl:element>
+    </xsl:template>
+    <xsl:template match="originalsloc[head = 'Existence and Location of Originals']">
+        <xsl:element name="note">
+            <xsl:attribute name="type">original location</xsl:attribute>
             <xsl:value-of select="normalize-space(p)"/>
         </xsl:element>
     </xsl:template>


### PR DESCRIPTION
**fix origination mapping**
* * *

**JIRA Ticket**: [(link)](https://jira.huit.harvard.edu/browse/LTSMAINT-746)
Subtask: https://jira.huit.harvard.edu/browse/LTSMAINT-800

# What does this Pull Request do?
Fix origination mapping in eadcomponent2mods.xsl; and bump spring core to 5.2.24.RELEASE (was high severity issue)

# How should this be tested?
Deploy ingest to qa (done)
Ingest gut50000.xml (done)
See the field that was previously missing in librarycloud qa:
https://api-qa.lib.harvard.edu/v2/items/GUT50000c01647
Field:
<mods:note type="original location">This issue is in the Alabama Collection at Auburn University Libraries.</mods:note>

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests?
- integration tests?

# Interested parties
Tag (@ mention) interested parties
