### PR TITLE
Exclude transitive log4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.21</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
 


### PR DESCRIPTION
[INC05236760](https://harvard.service-now.com/nav_to.do?uri=incident.do%3Fsys_id=0a2f8750978ff99070b03d700153af82%26sysparm_stack=incident_list.do%3Fsysparm_query=active=true)

# What does this Pull Request do?
This update excludes the transitive log4j dependency from the Maven build

# How should this be tested?
1. Ensure the build completes successfully
2. Ensure the deployed service runs as expected
3. Ensure logs are still be written

# Test coverage
- unit tests? no
- integration tests? no

# Interested parties
@michael-lts
